### PR TITLE
Don't completely hide the download exception

### DIFF
--- a/allosaurus/bin/download_model.py
+++ b/allosaurus/bin/download_model.py
@@ -27,8 +27,8 @@ def download_model(model_name=None, alt_model_path=None):
             files = tarfile.open(fileobj=compressed_files)
             files.extractall(str(model_dir))
 
-        except:
-            print("Error: could not download the model")
+        except Exception as e:
+            print("Error: could not download the model", e)
             (model_dir / model_name).rmdir()
 
 


### PR DESCRIPTION
Helps to debug if a download failure is due to e.g. a permissions error.